### PR TITLE
Fix text is not rendered correctly

### DIFF
--- a/src/HUD.cpp
+++ b/src/HUD.cpp
@@ -12,7 +12,7 @@ HUD::HUD(SDL_Renderer* ren, std::shared_ptr<Mario> mario, int time) : ren(ren), 
     textColor.r = 255;
     textColor.g = 255;
     textColor.b = 255;
-    textColor.a = 1;
+    textColor.a = 255;
 
     coinsRect.x = 300;
     coinsRect.y = 10;

--- a/src/Objects/AnimatedScore.cpp
+++ b/src/Objects/AnimatedScore.cpp
@@ -10,7 +10,7 @@ AnimatedScore::AnimatedScore(int x, int y, long startTime, int score, SDL_Render
     textColor.r = 255;
     textColor.g = 255;
     textColor.b = 255;
-    textColor.a = 1;
+    textColor.a = 255;
 
     SDL_Surface *animatedScoreText = TTF_RenderText_Solid(font, std::to_string(score).c_str(),
                                                           textColor);


### PR DESCRIPTION
I don't know at which point this became an issue, but current builds can't show text with the alpha values in codebase.